### PR TITLE
Fix reset_set API: fields boot and sw_reset were wrongly set

### DIFF
--- a/lsm6dsv16x_reg.c
+++ b/lsm6dsv16x_reg.c
@@ -439,9 +439,9 @@ int32_t lsm6dsv16x_reset_set(const stmdev_ctx_t *ctx, lsm6dsv16x_reset_t val)
     return ret;
   }
 
-  ctrl3.boot = ((uint8_t)val & 0x04U) >> 2;
-  ctrl3.sw_reset = ((uint8_t)val & 0x02U) >> 1;
-  func_cfg_access.sw_por = (uint8_t)val & 0x01U;
+  ctrl3.boot = (val == LSM6DSV16X_RESTORE_CAL_PARAM) ? 1 : 0;
+  ctrl3.sw_reset = (val == LSM6DSV16X_RESTORE_CTRL_REGS) ? 1 : 0;
+  func_cfg_access.sw_por = (val == LSM6DSV16X_GLOBAL_RST) ? 1 : 0;
 
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL3, (uint8_t *)&ctrl3, 1);
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);

--- a/lsm6dsv16x_reg.h
+++ b/lsm6dsv16x_reg.h
@@ -3918,10 +3918,11 @@ int32_t lsm6dsv16x_xl_offset_mg_get(const stmdev_ctx_t *ctx,
 
 typedef enum
 {
-  LSM6DSV16X_READY             = 0x0,
-  LSM6DSV16X_GLOBAL_RST        = 0x1,
-  LSM6DSV16X_RESTORE_CAL_PARAM = 0x2,
-  LSM6DSV16X_RESTORE_CTRL_REGS = 0x4,
+  LSM6DSV16X_READY             = 0x0, /* No active reset in progress */
+  LSM6DSV16X_GLOBAL_RST        = 0x1, /* Complete reset: boot, software reset,
+                                    embedded functions, and internal filters */
+  LSM6DSV16X_RESTORE_CAL_PARAM = 0x2, /* Reload trimming parameters */
+  LSM6DSV16X_RESTORE_CTRL_REGS = 0x4, /* Reset control registers to default values */
 } lsm6dsv16x_reset_t;
 int32_t lsm6dsv16x_reset_set(const stmdev_ctx_t *ctx, lsm6dsv16x_reset_t val);
 int32_t lsm6dsv16x_reset_get(const stmdev_ctx_t *ctx, lsm6dsv16x_reset_t *val);


### PR DESCRIPTION
This fix addresses issue #6: '_boot_' and '_sw_reset_' fields were not correctly associated with the reset_t enum.

Previously, `RESTORE_CAL_PARAM` (with value `0x2`) set the `sw_reset` field of the CTRL3 register, and `RESTORE_CTRL_REGS` (with value `0x4`) set the `boot` field. However, as described in [AN5763, section 5.7](https://www.st.com/resource/en/application_note/an5763-lsm6dsv16x-6axis-imu-with-embedded-sensor-fusion-ai-qvar-for-highend-applications-stmicroelectronics.pdf):

> After power-up, the trimming parameters can be reloaded by setting the BOOT bit of the CTRL3 register to 1.  
> If a reset to the default value of the control registers is required, it can be performed by setting the SW_RESET bit of the CTRL3 register to 1.

Their behaviors have now been switched to align with the datasheet.