### PR TITLE
(fix) do not jump to exit before initing master_config

### DIFF
--- a/lsm6dsv16x_reg.c
+++ b/lsm6dsv16x_reg.c
@@ -6782,10 +6782,6 @@ int32_t lsm6dsv16x_sflp_game_gbias_set(const stmdev_ctx_t *ctx,
   {
     ret += lsm6dsv16x_xl_data_rate_set(ctx, LSM6DSV16X_ODR_AT_120Hz);
   }
-  if (ret != 0)
-  {
-    goto exit;
-  }
 
   /* Make sure to turn the sensor-hub master off */
   ret += lsm6dsv16x_sh_master_get(ctx, &master_config);


### PR DESCRIPTION
Avoid jumping to exit before initing master_config to avoid a compiler warning. The value of ret is preserved and jump will be done anyway later on.

To generate warnings on zephyr:

```
export ZEPHYR_TOOLCHAIN_VARIANT=llvm
west build -p -b native_sim/native tests/drivers/build_all/sensor -T drivers.sensor.trigger.own.build

[787/829] Building C object modules/hal_st/CMakeFiles/..__modules__hal__st.dir/sensor/stmemsc/lsm6dsv16x_STdC/driver/lsm6dsv16x_reg.c.obj
/local/home/visconti/Projects/GIT/FW/zephyrproject/modules/hal/st/sensor/stmemsc/lsm6dsv16x_STdC/driver/lsm6dsv16x_reg.c:6785:7: warning: variable 'master_config' is used uninitialized whenever 'if' condition is true [-Wsometimes-uninitialized]
 6785 |   if (ret != 0)
      |       ^~~~~~~~
/local/home/visconti/Projects/GIT/FW/zephyrproject/modules/hal/st/sensor/stmemsc/lsm6dsv16x_STdC/driver/lsm6dsv16x_reg.c:6936:40: note: uninitialized use occurs here
 6936 |   ret += lsm6dsv16x_sh_master_set(ctx, master_config);
      |                                        ^~~~~~~~~~~~~
/local/home/visconti/Projects/GIT/FW/zephyrproject/modules/hal/st/sensor/stmemsc/lsm6dsv16x_STdC/driver/lsm6dsv16x_reg.c:6785:3: note: remove the 'if' if its condition is always false
 6785 |   if (ret != 0)
      |   ^~~~~~~~~~~~~
 6786 |   {
      |   ~
 6787 |     goto exit;
      |     ~~~~~~~~~~
 6788 |   }
      |   ~
/local/home/visconti/Projects/GIT/FW/zephyrproject/modules/hal/st/sensor/stmemsc/lsm6dsv16x_STdC/driver/lsm6dsv16x_reg.c:6725:24: note: initialize the variable 'master_config' to silence this warning
 6725 |   uint8_t master_config;
      |                        ^
      |                         = '\0'
1 warning generated.
```